### PR TITLE
Create infra for Mentoring app

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,2 @@
+.terraform
+.terraform.lock.hcl

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,14 @@
+data "terraform_remote_state" "vpc" {
+  backend = "s3"
+
+  config = {
+    bucket = "itsre-state-783633885093"
+    key    = "terraform/deploy.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+# TODO: Fill once the app is deployed
+#data "aws_elb" "mentoring_prod" {
+#  name = "" # To be determined
+#}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,42 @@
+# Docker registry
+module "ecr" {
+  source    = "github.com/mozilla-it/terraform-modules//aws/ecr?ref=master"
+  repo_name = "mentoring"
+}
+
+# Database
+module "database-prod" {
+  source     = "github.com/mozilla-it/terraform-modules//aws/database?ref=master"
+  instance   = "db.t3.micro"
+  type       = "postgres"
+  name       = "mentoring-prod"
+  username   = "mentoring"
+  identifier = "mentoring"
+  storage_gb = "5" # minimum allowed
+  db_version = "12.5"
+  multi_az   = "false"
+  subnets    = data.terraform_remote_state.vpc.outputs.private_subnets
+  vpc_id     = data.terraform_remote_state.vpc.outputs.vpc_id
+
+  cost_center = "1410"
+  project     = "mentoring"
+  environment = "prod"
+}
+
+# Route53
+resource "aws_route53_zone" "primary" {
+  name = "mentoring.mozilla.com"
+}
+
+# TODO: Will be created once the app is deployed
+#resource "aws_route53_record" "mentoring_prod" {
+#  zone_id = aws_route53_zone.primary.zone_id
+#  name    = "mentoring.mozilla.com"
+#  type    = "A"
+#
+#  alias {
+#    name                   = data.aws_elb.mentoring_prod.dns_name
+#    zone_id                = data.aws_elb.mentoring_prod.zone_id
+#    evaluate_target_health = false
+#  }
+#}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+terraform {
+  required_version = "~> 0.14"
+
+  backend "s3" {
+    # naming convention https://mana.mozilla.org/wiki/display/SRE/Terraform
+    bucket = "mentoring-state-783633885093"
+    key    = "state/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.27"
+    }
+  }
+  required_version = ">= 0.14"
+}


### PR DESCRIPTION
This PR creates the infra for the new Mentoring app:
 - Smalles PSQL instance
-  ECR repo
 - User with push rights to the ECR repo
 - DNS domain zone
 - DNS record for mentoring.mozilla.out (Commented out waiting on ELB creation)