### PR TITLE
remove mentoring.mozilla.com aws resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # mentoring-infra
+
+NOTE: This project has been decommissioned. This infrastructure no longer exists.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,58 +1,58 @@
-# Docker registry
-module "ecr" {
-  source    = "github.com/mozilla-it/terraform-modules//aws/ecr?ref=master"
-  repo_name = "mentoring"
-}
+# # Docker registry
+# module "ecr" {
+#   source    = "github.com/mozilla-it/terraform-modules//aws/ecr?ref=master"
+#   repo_name = "mentoring"
+# }
 
-# Database
-module "database-prod" {
-  source               = "github.com/mozilla-it/terraform-modules//aws/database?ref=master"
-  instance             = "db.t3.micro"
-  type                 = "postgres"
-  name                 = "mentoring"
-  username             = "mentoring"
-  identifier           = "mentoring-prod"
-  storage_gb           = "5" # minimum allowed
-  db_version           = "12.5"
-  parameter_group_name = "default.postgres12"
-  multi_az             = "false"
-  subnets              = data.terraform_remote_state.vpc.outputs.private_subnets
-  vpc_id               = data.terraform_remote_state.vpc.outputs.vpc_id
+# # Database
+# module "database-prod" {
+#   source               = "github.com/mozilla-it/terraform-modules//aws/database?ref=master"
+#   instance             = "db.t3.micro"
+#   type                 = "postgres"
+#   name                 = "mentoring"
+#   username             = "mentoring"
+#   identifier           = "mentoring-prod"
+#   storage_gb           = "5" # minimum allowed
+#   db_version           = "12.5"
+#   parameter_group_name = "default.postgres12"
+#   multi_az             = "false"
+#   subnets              = data.terraform_remote_state.vpc.outputs.private_subnets
+#   vpc_id               = data.terraform_remote_state.vpc.outputs.vpc_id
 
-  cost_center = "1410"
-  project     = "mentoring"
-  environment = "prod"
-}
+#   cost_center = "1410"
+#   project     = "mentoring"
+#   environment = "prod"
+# }
 
-# Route53
-resource "aws_route53_zone" "primary" {
-  name = "mentoring.mozilla.com"
-}
+# # Route53
+# resource "aws_route53_zone" "primary" {
+#   name = "mentoring.mozilla.com"
+# }
 
-# ACM
-resource "aws_acm_certificate" "mentoring_mozilla_com" {
-  domain_name       = "mentoring.mozilla.com"
-  validation_method = "DNS"
-}
+# # ACM
+# resource "aws_acm_certificate" "mentoring_mozilla_com" {
+#   domain_name       = "mentoring.mozilla.com"
+#   validation_method = "DNS"
+# }
 
-resource "aws_route53_record" "mentoring_mozilla_com" {
-  for_each = {
-    for dvo in aws_acm_certificate.mentoring_mozilla_com.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
+# resource "aws_route53_record" "mentoring_mozilla_com" {
+#   for_each = {
+#     for dvo in aws_acm_certificate.mentoring_mozilla_com.domain_validation_options : dvo.domain_name => {
+#       name   = dvo.resource_record_name
+#       record = dvo.resource_record_value
+#       type   = dvo.resource_record_type
+#     }
+#   }
 
-  allow_overwrite = true
-  name            = each.value.name
-  records         = [each.value.record]
-  ttl             = 60
-  type            = each.value.type
-  zone_id         = aws_route53_zone.primary.zone_id
-}
+#   allow_overwrite = true
+#   name            = each.value.name
+#   records         = [each.value.record]
+#   ttl             = 60
+#   type            = each.value.type
+#   zone_id         = aws_route53_zone.primary.zone_id
+# }
 
-resource "aws_acm_certificate_validation" "mentoring_mozilla_com" {
-  certificate_arn         = aws_acm_certificate.mentoring_mozilla_com.arn
-  validation_record_fqdns = [for record in aws_route53_record.mentoring_mozilla_com : record.fqdn]
-}
+# resource "aws_acm_certificate_validation" "mentoring_mozilla_com" {
+#   certificate_arn         = aws_acm_certificate.mentoring_mozilla_com.arn
+#   validation_record_fqdns = [for record in aws_route53_record.mentoring_mozilla_com : record.fqdn]
+# }


### PR DESCRIPTION
Jira ticket: https://jira.mozilla.com/browse/SE-1978

What this PR does:
* removes AWS resources for mentoring.mozilla.com

Why do this now:
* already decomming other mentoring stuff for the cluster migration work

Next steps after PR approval:
1. ~run terraform apply, removing all mentoring resources~
2. ~check infoblox for any lingering DNS related to mentoring~
3. ~archive this git repository (or ask someone with sufficient git permissions to archive it)~
4. ~remove the terraform state bucket related to this project~

Note: I comment out the resources instead of straight out delete the file in case its ever helpful in terms of searching archived repos in the future. Also can just delete the terraform files if preferred.
